### PR TITLE
Update to 1.3.10

### DIFF
--- a/recipe/SConstruct.diff
+++ b/recipe/SConstruct.diff
@@ -9,30 +9,12 @@
      if target in build_targets:
        return PathVariable.PathIsDirCreate(key, val, env)
      else:
-@@ -157,6 +157,8 @@
+@@ -166,6 +166,8 @@
                    CPPPATH=['.', ],
                    )
- 
+
 +env.Append( ENV = {'PATH': os.environ['PATH'] } )
 +
  env.Append(BUILDERS = {
-     'GenDef' : 
+     'GenDef' :
        Builder(action = sys.executable + ' build/gen_def.py $SOURCES > $TARGET',
-@@ -166,7 +168,7 @@
- match = re.search('SERF_MAJOR_VERSION ([0-9]+).*'
-                   'SERF_MINOR_VERSION ([0-9]+).*'
-                   'SERF_PATCH_VERSION ([0-9]+)',
--                  env.File('serf.h').get_contents(),
-+                  env.File('serf.h').get_contents().decode('utf-8'),
-                   re.DOTALL)
- MAJOR, MINOR, PATCH = [int(x) for x in match.groups()]
- env.Append(MAJOR=str(MAJOR))
-@@ -183,7 +185,7 @@
- 
- unknown = opts.UnknownVariables()
- if unknown:
--  print 'Warning: Used unknown variables:', ', '.join(unknown.keys())
-+  print('Warning: Used unknown variables:', ', '.join(list(unknown.keys())))
- 
- apr = str(env['APR'])
- apu = str(env['APU'])

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
   number: 0
+  # libapr and libaprutil are not availale n these platforms (as of August 2023).
   skip: True # [s390x or aarch64]
   run_exports:
     # https://abi-laboratory.pro/tracker/timeline/serf/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,15 @@ source:
   sha256: be81ef08baa2516ecda76a77adf7def7bc3227eeb578b9a33b45f7b41dc064e6
 
 build:
+  skip: True # [s390x or aarch64]
   run_exports:
     # https://abi-laboratory.pro/tracker/timeline/serf/
     # They keep changing soname b/w patch versions :'(
     - {{ pin_subpackage('serf', max_pin='x.x') }}
   ignore_run_exports:
     - expat
+  patches:
+    - SConstruct.diff
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,11 +25,15 @@ requirements:
     - patch     # [not win]
     - m2-patch  # [win]
   host:
-    - apr
+    - libapr
+    - libaprutil
     - openssl
     - scons
     - zlib
     - expat
+  run:
+    - libapr
+    - libaprutil
 
   build:
     - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
     - SConstruct.diff
 
 build:
+  build: 0
+  skip: True # [s390x or aarch64]
   run_exports:
     # https://abi-laboratory.pro/tracker/timeline/serf/
     # They keep changing soname b/w patch versions :'(
@@ -26,7 +28,7 @@ requirements:
   host:
     - libapr
     - libaprutil
-    - openssl
+    - openssl {{ openssl }}
     - scons
     - zlib
     - expat
@@ -56,13 +58,13 @@ test:
 
 
 about:
-  home: http://serf.apache.org/
-  license: Apache License 2.0
+  home: https://serf.apache.org/
+  license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
   summary: High performance C-based HTTP client library
   description: |
     Serf is a simple web server. It is a development tool to be used during the
     development of rich internet applications.It is not intended for deployment.
-  doc_url: https://pythonhosted.org/serf/
-  dev_url: https://www.openhub.net/p/serf
+  doc_url: https://serf.apache.org/
+  dev_url: https://serf.apache.org/contribute

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
     - SConstruct.diff
 
 build:
-  skip: True # [s390x or aarch64]
   run_exports:
     # https://abi-laboratory.pro/tracker/timeline/serf/
     # They keep changing soname b/w patch versions :'(

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
   run:
     - libapr
     - libaprutil
+    - openssl # pin handled through openssl run_exports
 
   build:
     - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - SConstruct.diff
 
 build:
-  build: 0
+  number: 0
   skip: True # [s390x or aarch64]
   run_exports:
     # https://abi-laboratory.pro/tracker/timeline/serf/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,8 @@ test:
     - test -f ${PREFIX}/lib/libserf-1${SHLIB_EXT}   # [unix]
 
     - conda inspect linkages -p ${PREFIX} serf  # [not win]
-    - conda inspect objects -p ${PREFIX} serf   # [osx]
+    # conda inspect objects no longer supported
+    #- conda inspect objects -p ${PREFIX} serf   # [osx]
 
 about:
   home: http://serf.apache.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ source:
   fn:  serf-{{ version }}.tar.bz2
   url: https://archive.apache.org/dist/serf/serf-{{ version }}.tar.bz2
   sha256: be81ef08baa2516ecda76a77adf7def7bc3227eeb578b9a33b45f7b41dc064e6
+  patches:
+    - SConstruct.diff
 
 build:
   skip: True # [s390x or aarch64]
@@ -17,8 +19,6 @@ build:
     - {{ pin_subpackage('serf', max_pin='x.x') }}
   ignore_run_exports:
     - expat
-  patches:
-    - SConstruct.diff
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,9 +54,6 @@ test:
     - test -f ${PREFIX}/include/serf-1/serf.h       # [unix]
     - test -f ${PREFIX}/lib/libserf-1${SHLIB_EXT}   # [unix]
 
-    - conda inspect linkages -p ${PREFIX} serf  # [not win]
-    # conda inspect objects no longer supported
-    #- conda inspect objects -p ${PREFIX} serf   # [osx]
 
 about:
   home: http://serf.apache.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.9" %}
+{% set version = "1.3.10" %}
 
 package:
   name: serf
@@ -7,9 +7,7 @@ package:
 source:
   fn:  serf-{{ version }}.tar.bz2
   url: https://archive.apache.org/dist/serf/serf-{{ version }}.tar.bz2
-  sha256: 549c2d21c577a8a9c0450facb5cca809f26591f048e466552240947bdf7a87cc
-  patches:
-    - SConstruct.diff
+  sha256: be81ef08baa2516ecda76a77adf7def7bc3227eeb578b9a33b45f7b41dc064e6
 
 build:
   run_exports:


### PR DESCRIPTION
- Updated version and hash
- Made choice to skip for s390x and ppc64le as they were broken and not supported right now.
- Focused on apr parts that were only necessary
- Edited Patch as some of the fixes had been applied to upstream
- Removed deprecated conda commands from test section 